### PR TITLE
fix: ssl cert error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-w -s" -o ./drone-crowdin-v2 ./cm
 # RUN
 FROM scratch
 
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /build/drone-crowdin-v2 /
 
 CMD [ "/drone-crowdin-v2" ]


### PR DESCRIPTION
Running the plugin results in the following error:

error: crowdin api: Post "https://api.crowdin.com/api/v2/projects/ID/translations/builds": tls: failed to verify certificate: x509: certificate signed by unknown authority

The scratch image does not contain the necessary root certificates to verify the certificate from crowdin.com. We need to copy them in before doing that.