### PR TITLE
fix: build for armv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD
-FROM docker.io/library/golang:1.21.5 as build
+FROM golang:1-alpine as build
 
 WORKDIR /build
 


### PR DESCRIPTION
I noticed the builds for armv6 are failing. Using the golang alpine image as a base fixes that.