### PR TITLE
fix: add /tmp folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,6 @@ FROM scratch
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /build/drone-crowdin-v2 /
+COPY --from=build /tmp /tmp
 
 CMD [ "/drone-crowdin-v2" ]


### PR DESCRIPTION
I've noticed the plugin would fail to update translation files with this error:

```
error: crowdin api: failed create temp file: open /tmp/drone-crowdin-v2-1496125452: no such file or directory
```

Since this is based on the `scratch` image, there was no `/tmp` folder. This PR adds one into the final image.